### PR TITLE
Replace whitelist/blacklist with allowlist/denylist.

### DIFF
--- a/vendor/github.com/go-sql-driver/mysql/README.md
+++ b/vendor/github.com/go-sql-driver/mysql/README.md
@@ -211,7 +211,7 @@ Default:        false
 
 If `interpolateParams` is true, placeholders (`?`) in calls to `db.Query()` and `db.Exec()` are interpolated into a single query string with given parameters. This reduces the number of roundtrips, since the driver has to prepare a statement, execute it with given parameters and close the statement again with `interpolateParams=false`.
 
-*This can not be used together with the multibyte encodings BIG5, CP932, GB2312, GBK or SJIS. These are blacklisted as they may [introduce a SQL injection vulnerability](http://stackoverflow.com/a/12118602/3430118)!*
+*This can not be used together with the multibyte encodings BIG5, CP932, GB2312, GBK or SJIS. These are denylisted as they may [introduce a SQL injection vulnerability](http://stackoverflow.com/a/12118602/3430118)!*
 
 ##### `loc`
 
@@ -392,7 +392,7 @@ For this feature you need direct access to the package. Therefore you must chang
 import "github.com/go-sql-driver/mysql"
 ```
 
-Files must be whitelisted by registering them with `mysql.RegisterLocalFile(filepath)` (recommended) or the Whitelist check must be deactivated by using the DSN parameter `allowAllFiles=true` ([*Might be insecure!*](http://dev.mysql.com/doc/refman/5.7/en/load-data-local.html)).
+Files must be allowlisted by registering them with `mysql.RegisterLocalFile(filepath)` (recommended) or the Whitelist check must be deactivated by using the DSN parameter `allowAllFiles=true` ([*Might be insecure!*](http://dev.mysql.com/doc/refman/5.7/en/load-data-local.html)).
 
 To use a `io.Reader` a handler function must be registered with `mysql.RegisterReaderHandler(name, handler)` which returns a `io.Reader` or `io.ReadCloser`. The Reader is available with the filepath `Reader::<name>` then. Choose different names for different handlers and `DeregisterReaderHandler` when you don't need it anymore.
 

--- a/vendor/github.com/hashicorp/vault/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/vault/CHANGELOG.md
@@ -571,7 +571,7 @@ FEATURES:
    `sys/leases` endpoints in the API. These are located in the new top level
    navigation item "Leases".
  * **Filtered Mounts for Performance Mode Replication**: Whitelists or
-   blacklists of mounts can be defined per-secondary to control which mounts
+   denylists of mounts can be defined per-secondary to control which mounts
    are actually replicated to that secondary. This can allow targeted
    replication of specific sets of data to specific geolocations/datacenters.
  * **Disaster Recovery Mode Replication (Enterprise Only)**: There is a new
@@ -1006,7 +1006,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
  * auth/token: Fix regression in 0.6.4 where using token store roles as a
-   blacklist (with only `disallowed_policies` set) would not work in most
+   denylist (with only `disallowed_policies` set) would not work in most
    circumstances [GH-2286]
  * physical/s3: Page responses in client so list doesn't truncate [GH-2224]
  * secret/cassandra: Stop a connection leak that could occur on active node
@@ -1404,7 +1404,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
- * auth/aws-ec2: Added a nil check for stored whitelist identity object
+ * auth/aws-ec2: Added a nil check for stored allowlist identity object
    during renewal [GH-1542]
  * auth/cert: Fix panic if no client certificate is supplied [GH-1637]
  * auth/token: Don't report that a non-expiring root token is renewable, as


### PR DESCRIPTION
This replaces the terms whitelist/blacklist in Markdown files with allowlist/denylist

[_Created by Sourcegraph campaign `emily/use-allowlist-denylist-wording-2021-02-05-new`._](https://demo.sourcegraph.com/users/emily/campaigns/use-allowlist-denylist-wording-2021-02-05-new)